### PR TITLE
修复错误的最高清晰度

### DIFF
--- a/down_one.py
+++ b/down_one.py
@@ -227,7 +227,7 @@ class Xvideos:
             base_url = re.search(r"(.*?)hls.m3u8", m3u8_url).group(1)  # 从m3u8_url中取出，留待拼接
             m3u8_content = m3u8_content.decode('utf-8')
             definition_list = re.findall(r'NAME="(.*?)p"', m3u8_content)
-            max_definition = max(definition_list)  # 找到最高清晰度
+            max_definition = str(max(list(map(int,definition_list))))  # 找到最高清晰度
             line_list = m3u8_content.split('\n')
             for line in line_list:
                 if 'hls-' in line and max_definition in line:


### PR DESCRIPTION
  definition_list = re.findall(r'NAME="(.*?)p"', m3u8_content)
  definition_list
['480', '720', '1080', '360', '250']
  max_definition = max(definition_list)
  max_definition
'720'
  max_definition = str(max(list(map(int,definition_list))))
  max_definition
'1080'